### PR TITLE
Support RN 0.49

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ export default class SliderVolumeController extends Component {
           
             slider = <ReactNativeVolumeControllerSlider {...rest}
                                                         onValueChange={onValueChange}
-                                                        style={[styles.slider, style, {width:sliderWidth}]}/>
+                                                        style={[styles.slider, {width:sliderWidth}, style]}/>
         }
 
         return(<View style={[this.props.style, {marginLeft:10, marginRight:10,flex:1, flexDirection:"row", width:viewWidth,

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes }  from 'react';
+import React, { Component }  from 'react';
+import PropTypes from 'prop-types';
 import { View, NativeModules, DeviceEventEmitter, Slider, requireNativeComponent, Image, Platform, Dimensions, Text, StyleSheet } from 'react-native';
 
 const ReactNativeVolumeController = NativeModules.ReactNativeVolumeController;

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   },
   "devDependencies": {
     "react-native": ">=0.31.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
PropTypes in React are gone, changes to the prop-type library.

Also changes the order of the slider style so the width is more important than the style